### PR TITLE
chrome driver linux32 download link tested again

### DIFF
--- a/test/default-downloads-test.js
+++ b/test/default-downloads-test.js
@@ -128,6 +128,23 @@ describe('default-downloads', function() {
           value: 'linux'
         });
       });
+      
+      if(opts.drivers.chrome.version < 2.34) {
+        it('ia32 download exists', function(done) {
+          opts = merge(opts, {
+            drivers: {
+              chrome: {
+                arch: 'ia32'
+              }
+            }
+          });
+
+          computedUrls = computeDownloadUrls(opts);
+
+          assert(computedUrls.chrome.indexOf('linux32') > 0);
+          doesDownloadExist(computedUrls.chrome, done);
+        });
+      }
 
       it('x64 download exists', function(done) {
         opts = merge(opts, {


### PR DESCRIPTION
It seems that Google stopped providing 32 bit versions of chrome driver beginning from version 2.34. That's why I made this test to be run conditionally. It might comply with @stephenash suggestions to keep it just in case someone would like to build the project with older chrome driver version configured.